### PR TITLE
Add 'aws_site_error_document' config support

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -1,4 +1,4 @@
-name: 'Deploy static site to AWS S3'
+name: 'Deploy static site to AWS (S3+CDN+R53)'
 description: 'Deploy a website to an S3 bucket. Option to add Cloudfront, and deploy to a Route53 managed domain with certs.'
 branding:
   icon: upload-cloud

--- a/action.yaml
+++ b/action.yaml
@@ -55,6 +55,9 @@ inputs:
   aws_site_root_object:
     description: 'Root object to be served as entry-point. Defaults to `index.html`'
     required: false
+  aws_site_error_document:
+    description: 'Error document set to S3 website config. Defaults to `error.html`'
+    required: false
   aws_site_bucket_name:
     description: ' AWS S3 bucket name to use for the public files. Defaults to `${org}-${repo}-{branch}-sp`'
     required: false
@@ -121,6 +124,7 @@ runs:
         # Site
         AWS_SITE_SOURCE_FOLDER: ${{ inputs.aws_site_source_folder }}
         AWS_SITE_ROOT_OBJECT: ${{ inputs.aws_site_root_object }}
+        AWS_SITE_ERROR_DOCUMENT: ${{ inputs.aws_site_error_document }}
         AWS_SITE_BUCKET_NAME: ${{ inputs.aws_site_bucket_name }}
         AWS_SITE_CDN_ENABLED: ${{ inputs.aws_site_cdn_enabled }}
         AWS_SITE_CDN_CUSTOM_ERROR_CODES: ${{ inputs.aws_site_cdn_custom_error_codes }}

--- a/action.yaml
+++ b/action.yaml
@@ -1,4 +1,4 @@
-name: 'Deploy static site to AWS (S3+CDN+R53)'
+name: 'Deploy static site to AWS S3'
 description: 'Deploy a website to an S3 bucket. Option to add Cloudfront, and deploy to a Route53 managed domain with certs.'
 branding:
   icon: upload-cloud

--- a/scripts/generate_deploy.sh
+++ b/scripts/generate_deploy.sh
@@ -90,6 +90,7 @@ aws_site_bucket_name=$(generate_var aws_site_bucket_name $AWS_SITE_BUCKET_NAME)
 aws_site_cdn_enabled=$(generate_var aws_site_cdn_enabled $AWS_SITE_CDN_ENABLED)
 aws_site_cdn_custom_error_codes=$(generate_var aws_site_cdn_custom_error_codes $AWS_SITE_CDN_CUSTOM_ERROR_CODES)
 aws_site_root_object=$(generate_var aws_site_root_object $AWS_SITE_ROOT_OBJECT)
+aws_site_error_document=$(generate_var aws_site_error_document $AWS_SITE_ERROR_DOCUMENT)
 aws_r53_domain_name=$(generate_var aws_r53_domain_name $AWS_R53_DOMAIN_NAME)
 aws_r53_root_domain_deploy=$(generate_var aws_r53_root_domain_deploy $AWS_R53_ROOT_DOMAIN_DEPLOY)
 #aws_r53_enable_cert=$(generate_var aws_r53_enable_cert $AWS_R53_ENABLE_CERT)
@@ -110,6 +111,7 @@ $aws_site_bucket_name
 $aws_site_cdn_enabled
 $aws_site_cdn_custom_error_codes
 $aws_site_root_object
+$aws_site_error_document
 $aws_r53_domain_name
 $aws_r53_sub_domain_name
 $aws_r53_root_domain_deploy

--- a/terraform_code/main.tf
+++ b/terraform_code/main.tf
@@ -9,6 +9,10 @@ resource "aws_s3_bucket_website_configuration" "aws_site_website_bucket" {
   index_document {
     suffix = var.aws_site_root_object
   }
+
+  error_document {
+    key = var.aws_site_error_document
+  }
 }
 
 ## Only create this two IF -> R53 FQDN provided and CDN is off - for www.* support

--- a/terraform_code/variables.tf
+++ b/terraform_code/variables.tf
@@ -32,7 +32,7 @@ variable "aws_site_root_object" {
 }
 
 variable "aws_site_error_document" {
-  description = "error document. Defaults to error.html"
+  description = "error document. Defaults to empty"
   type        = string
   default     = ""
 }

--- a/terraform_code/variables.tf
+++ b/terraform_code/variables.tf
@@ -34,7 +34,7 @@ variable "aws_site_root_object" {
 variable "aws_site_error_document" {
   description = "error document. Defaults to error.html"
   type        = string
-  default     = "error.html"
+  default     = ""
 }
 
 variable "aws_site_bucket_name" {

--- a/terraform_code/variables.tf
+++ b/terraform_code/variables.tf
@@ -31,6 +31,12 @@ variable "aws_site_root_object" {
   default     = "index.html"
 }
 
+variable "aws_site_error_document" {
+  description = "error document. Defaults to error.html"
+  type        = string
+  default     = "error.html"
+}
+
 variable "aws_site_bucket_name" {
   description = "Bucket name where all the files will be stored."
   type        = string


### PR DESCRIPTION
I have tried adding the aws_site_error_document configuration, which provides users with a new option to decide whether to modify the error_document configuration when setting up the AWS S3 website.

